### PR TITLE
matcher implement binary search variant. also profiling flags

### DIFF
--- a/matcher/bsearch.go
+++ b/matcher/bsearch.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"sort"
+)
+
+type slice []string
+
+var data slice
+
+func (a slice) Len() int { return len(a) }
+
+func (a slice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a slice) Less(i, j int) bool { return a[i] < a[j] }
+
+func initBsearch() {
+
+	f, err := os.Open("domains.txt")
+	if err != nil {
+		log.Fatalf("err=%v", err)
+	}
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		data = append(data, scanner.Text())
+	}
+	sort.Sort(data)
+}
+
+func MatchBsearch(k []byte) bool {
+	in := string(k)
+	i := sort.SearchStrings(data, in)
+	// the search fn gives the pos where it should be (if it's not there, where to insert it)
+	// so we still need to verify
+	if i < len(data) && data[i] == in {
+		return true
+	}
+	return false
+}

--- a/matcher/main.go
+++ b/matcher/main.go
@@ -7,15 +7,18 @@ import (
 	"flag"
 	"log"
 	"os"
+	"runtime/pprof"
 	"time"
 )
 
 func main() {
 
 	f := flag.String("f", "/dev/stdin", "input file")
-	w := flag.String("which", "ragel", "which matcher")
+	w := flag.String("which", "ragel", "which matcher (one of: bsearch, map, radix, ragel, aho. defaults to ragel.)")
 	n := flag.Int("n", 2000000, "size")
 	iter := flag.Int("i", 10, "iterations")
+	cpuprofile := flag.String("cpuprofile", "", "write cpu profile to file")
+	memprofile := flag.String("memprofile", "", "write memory profile to this file")
 
 	flag.Parse()
 
@@ -34,7 +37,40 @@ func main() {
 
 	log.Printf("using matcher=%+v\n", *w)
 
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+	if *memprofile != "" {
+		f, err := os.Create(*memprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		defer pprof.WriteHeapProfile(f)
+	}
+
 	switch *w {
+
+	case "bsearch":
+		initBsearch()
+
+		t0 := time.Now()
+		var found int
+		for i := 0; i < *iter; i++ {
+			for _, a := range arr[:*n] {
+				if MatchBsearch(a) {
+					found++
+				}
+
+			}
+		}
+		log.Printf("time.Since(t0)=%+v\n", time.Since(t0))
+		log.Printf("found=%+v\n", found)
 
 	case "map":
 		initMap()


### PR DESCRIPTION
pretty disappointed though...

Damian had mentioned "The others are all basically O(length of text);
switching to O(log patterns) will be a significant slowdown."

But I thought O() aside, hashing would incur significant overhead that
is not caputured in O(), which binary search doesn't suffer from.
Guess I was wrong.
At least it's not the worst.

$ for i in aho radix ragel map bsearch; do ./matcher -f ./domains.txt -which $i -n 999; done
2015/08/30 16:14:54 using matcher=aho
2015/08/30 16:14:54 time.Since(t0)=2.369577ms
2015/08/30 16:14:54 found=9990
2015/08/30 16:14:54 using matcher=radix
2015/08/30 16:14:54 time.Since(t0)=1.995988ms
2015/08/30 16:14:54 found=9990
2015/08/30 16:14:54 using matcher=ragel
2015/08/30 16:14:54 time.Since(t0)=1.524866ms
2015/08/30 16:14:54 found=9990
2015/08/30 16:14:54 using matcher=map
2015/08/30 16:14:54 time.Since(t0)=366.444µs
2015/08/30 16:14:54 found=9990
2015/08/30 16:14:54 using matcher=bsearch
2015/08/30 16:14:54 time.Since(t0)=2.085808ms
2015/08/30 16:14:54 found=9990