### PR TITLE
tweaks build on smhasher and pass test

### DIFF
--- a/tsip/tsip.c
+++ b/tsip/tsip.c
@@ -1,26 +1,40 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdint.h>
 #include <stdio.h>
 
-static uint64_t inline U8TO64_LE(const unsigned char *p) {
+
+#define TSIP_STATIC_INLINE static inline
+#define STRLEN int
+
+TSIP_STATIC_INLINE
+uint64_t U8TO64_LE(const unsigned char *p) {
   return *(const uint64_t *)p;
 }
 
-static uint64_t rotl64(uint64_t x, int k) {
+TSIP_STATIC_INLINE
+uint64_t rotl64(uint64_t x, int k) {
   return (((x) << (k)) | ((x) >> (64 - k)));
 }
 
-uint64_t tsip(const unsigned char *seed, const unsigned char *m, size_t len) {
+TSIP_STATIC_INLINE
+void tsip_seed_state(const unsigned char *seed, unsigned char *state_ch) {
+  uint64_t *state= (uint64_t *)state_ch;
+  state[0] = U8TO64_LE(seed+0) ^ 0x736f6d6570736575ull;
+  state[1] = U8TO64_LE(seed+8) ^ 0x646f72616e646f6dull;
+}
+
+TSIP_STATIC_INLINE
+uint64_t tsip_hash_with_state(const unsigned char *state, const unsigned char *m, size_t len) {
 
   uint64_t v0, v1;
-  uint64_t mi, k0, k1;
+  uint64_t mi;
   uint64_t last7;
 
-  k0 = U8TO64_LE(seed);
-  k1 = U8TO64_LE(seed + 8);
-
-  v0 = k0 ^ 0x736f6d6570736575ull;
-  v1 = k1 ^ 0x646f72616e646f6dull;
+  v0 = U8TO64_LE(state);
+  v1 = U8TO64_LE(state + 8);
 
   last7 = (uint64_t)(len & 0xff) << 56;
 
@@ -72,6 +86,29 @@ uint64_t tsip(const unsigned char *seed, const unsigned char *m, size_t len) {
   v1 = rotl64(v1, 32);
   sipcompress();
   v1 = rotl64(v1, 32);
+  sipcompress();
+  v1 = rotl64(v1, 32);
 
   return v0 ^ v1;
 }
+
+TSIP_STATIC_INLINE
+uint64_t tsip_hash(const unsigned char *seed, const unsigned char *m, size_t len) {
+  uint64_t state[2];
+  tsip_seed_state(seed,(unsigned char*)state);
+  return tsip_hash_with_state((unsigned char*)state, m, len);
+}
+
+
+void tsip_seed_state_smhasher_test(int in_bits, const void *seed, void *state) {
+    tsip_seed_state((unsigned char*)seed,(unsigned char *)state);
+}
+
+void tsip_hash_with_state_smhasher_test(const void *key, STRLEN len, const void *state, void *out) {
+    *((uint64_t *)out)= tsip_hash_with_state((unsigned char*)state, (unsigned char *)key, len);
+}
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
tsip needed an extra mix round to pass avalanche tests, I have to
admit I question the test that generally failed (the 1% test), so
it may be a false positive, but other hashes do pass, so I don't
know. Adding an extra round fixed it.

Also the code needed some restructuring to build in c++ under smhasher.

It would be nicer if the code was all in a single .h file like i have done with the beagle hash stuff.

Not sure if you want to *actually* merge this, but it shows what I did to make it build on my smhasher, and I knew this would get your attention. ;-)

FWIW, I have a concern about zero seeds. If a user is unlucky to get an all zero seed (for instance, if their seed was the same value as the xor constants) they could have very poor results. Not sure the best approach to that. Maybe use something like I do in the hashes in BeagleHash, and mix in the length multiplied by a large prime to start into one or both of the state vectors (I use (len+1)*p, (len+2)*p etc, so that for every length at least one, if not all state vectors are affected [NB: consider len rollove, or len=0 cases]). Which should mean that instead of having a bad seed for all matches you would have one bad seed per length. It would also make key-extension attacks less likely, if not impossible, as each length would have a different initial state.

Anyway, nice stuff, smhasher is running right now.