### PR TITLE
Print phrase inside brackets as an optional flag

### DIFF
--- a/pphrase/main.go
+++ b/pphrase/main.go
@@ -13,6 +13,7 @@ func main() {
 
 	wordlist := flag.String("w", "words.txt", "word list to use")
 	phraseLen := flag.Int("n", 5, "length of passphrase")
+	bracketed := flag.Bool("bracketed", false, "return passphrase inside brackets")
 
 	flag.Parse()
 
@@ -48,6 +49,13 @@ func main() {
 		phrase = append(phrase, words[word])
 	}
 
-	fmt.Println(phrase)
+	if *bracketed {
+		fmt.Println(phrase)
+	} else {
+		for _, word := range phrase {
+			fmt.Print(word + " ")
+		}
+		fmt.Println()
+	}
 
 }


### PR DESCRIPTION
Added `bracketed` boolFlag (default: false) which provides the previous
printing behaviour `[first second third fourth fifth]` as an _option_,
but makes the default result `first second third fourth fifth`.

The brackets are an impediment, particularly for piping the output to
something else – particularly the clipboard (e.g. `pphrase | pbcopy`).

I can't see the practical use for printing this inside brackets, it's just
the Go behaviour for printing a slice of anything. If you want me to make
the `bracketed` flag default to true instead, preserving current behaviour,
that's fine, but I would be curious to hear the rationale, if possible?

(I use `pphrase` all the time but the brackets have pissed me off for years
– finally decided to do something about it.) 