### PR TITLE
github.com/OneOfOne/xxhash/native no longer exists

### DIFF
--- a/hashbench/bench_test.go
+++ b/hashbench/bench_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	xxhash "github.com/OneOfOne/xxhash/native"
+	xxhash "github.com/OneOfOne/xxhash"
 	xxhashfast "github.com/cespare/xxhash"
 	dchestsip "github.com/dchest/siphash"
 	"github.com/dgryski/go-farm"


### PR DESCRIPTION
`github.com/OneOfOne/xxhash/native` no longer exists.  Now its just `github.com/OneOfOne/xxhash`